### PR TITLE
Fix a couple small typos in circuit export

### DIFF
--- a/src/qrisp/circuit/quantum_circuit.py
+++ b/src/qrisp/circuit/quantum_circuit.py
@@ -1630,12 +1630,12 @@ class QuantumCircuit:
     
     def to_pytket(self):
         """
-        Method to convert the given QuantumCircuit to a Pennylane Circuit.
+        Method to convert the given QuantumCircuit to a pytket Circuit.
 
         Returns
         -------
         function
-            A function representing a pennylane QuantumCircuit.
+            A function representing a pytket QuantumCircuit.
 
         """
         from qrisp.interface.converter.convert_to_pytket import pytket_converter


### PR DESCRIPTION
I spotted a couple of typos in the docs for `to_pytket`. Made a quick fix.

Look forward to trying out qrisp :) 